### PR TITLE
minor changes to nav_bar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,8 +42,8 @@ navbar_pages:
   Main: "/"
   News: "/news/"
   Tensors: "/tensors/"
+  Tools: "https://github.com/frostt-tensor"
   Contribute: "/contribute/"
-  GitHub: "https://github.com/frostt-tensor"
 
 show_downloads: false
 google_analytics: UA-90336800-1


### PR DESCRIPTION
The "GitHub" link is now renamed to "Tools" to better align with the FROSTT name. "Contribute" is moved to the end of the list.