### PR TITLE
Create Kripke Tensor of Execution Times

### DIFF
--- a/_tensors/kripke_tensor.md
+++ b/_tensors/kripke_tensor.md
@@ -1,0 +1,44 @@
+---
+title: kripke tensor
+
+description: >
+  Execution times of the KRIPKE mini-app run on the Stampede2 supercomputer.
+  Modes represent benchmark parameters that influence execution time.
+  Each tensor element is characterized by an entry in the following columns (zero-indexed): {2,3,4,5,6,10,11,15,16}.
+  Each corresponding execution time is stored in the 25th column (zero-indexed).
+  
+    
+  
+# Tensor statistics
+order: '9'
+nnz: '32768'
+dims: ['7', '7', '6', '8', '6', '16', '8', '5', '2']
+
+
+# Each entry is a list ["URL", "description"]
+files:
+ - ["https://raw.githubusercontent.com/huttered40/app_ed/main/datasets/stampede2/kripke/kt0_nnodes1.csv?token=GHSAT0AAAAAACBEFS3ZCXTUOB5JNUCGSRQUZB3DF2Q", "kripke tensor"]
+
+# bibtex citation
+
+citation: >
+  @misc{hutter2022highdimensional,
+    title={High-Dimensional Performance Modeling via Tensor Completion}, 
+    author={Edward Hutter and Edgar Solomonik},
+    year={2022},
+    eprint={2210.10184},
+    archivePrefix={arXiv},
+    primaryClass={cs.PF}
+  }
+  @techreport{kunen2015kripke,
+    title={Kripke-a massively parallel transport mini-app},
+    author={Kunen, Adam J and Bailey, Teresa S and Brown, Peter N},
+    year={2015},
+    institution={Lawrence Livermore National Lab.(LLNL), Livermore, CA (United States)}
+  }
+  
+
+# Where to file the tensor?
+tags: [execution time]
+
+---


### PR DESCRIPTION
I seek to add multiple tensors to this open-source repository. The first is this tensor of execution times of the Kripke application. I will wait to open a pull request for the others until we agree on the right format for these files.

Some questions/comments:
1. Is the raw datafile from my public Github repository acceptable?
2. This is performance data acquired using an open-source mini-app (https://github.com/LLNL/Kripke). After reading the licensing, it seems like this data can be freely used.